### PR TITLE
Fixed the upvote error and added react-notify

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -19,7 +19,6 @@
         "react-hot-toast": "^2.5.2",
         "react-icons": "^5.5.0",
         "react-router-dom": "^7.5.2",
-        "react-toastify": "^11.0.5",
         "rollup": "^4.40.1"
       },
       "devDependencies": {
@@ -4312,19 +4311,6 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
-      }
-    },
-    "node_modules/react-toastify": {
-      "version": "11.0.5",
-      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.5.tgz",
-      "integrity": "sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==",
-      "license": "MIT",
-      "dependencies": {
-        "clsx": "^2.1.1"
-      },
-      "peerDependencies": {
-        "react": "^18 || ^19",
-        "react-dom": "^18 || ^19"
       }
     },
     "node_modules/require-directory": {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -19,6 +19,7 @@
         "react-hot-toast": "^2.5.2",
         "react-icons": "^5.5.0",
         "react-router-dom": "^7.5.2",
+        "react-toastify": "^11.0.5",
         "rollup": "^4.40.1"
       },
       "devDependencies": {
@@ -2606,6 +2607,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -4302,6 +4312,19 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.5.tgz",
+      "integrity": "sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
       }
     },
     "node_modules/require-directory": {

--- a/client/package.json
+++ b/client/package.json
@@ -21,7 +21,6 @@
     "react-hot-toast": "^2.5.2",
     "react-icons": "^5.5.0",
     "react-router-dom": "^7.5.2",
-    "react-toastify": "^11.0.5",
     "rollup": "^4.40.1"
   },
   "devDependencies": {

--- a/client/package.json
+++ b/client/package.json
@@ -21,6 +21,7 @@
     "react-hot-toast": "^2.5.2",
     "react-icons": "^5.5.0",
     "react-router-dom": "^7.5.2",
+    "react-toastify": "^11.0.5",
     "rollup": "^4.40.1"
   },
   "devDependencies": {

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -18,7 +18,6 @@ import About from './pages/About'
 import ContactUs from './pages/ContactUs'
 import ReactGA from "react-ga4";
 import usePageTracking from './hooks/usePageTracking';
-import { Toaster } from 'react-hot-toast';
 
 ReactGA.initialize(import.meta.env.VITE_GA_MEASUREMENT_ID);
 function App() {

--- a/client/src/components/NotesCard.jsx
+++ b/client/src/components/NotesCard.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { useAuth } from "../context/AuthContext";
+import toast, { Toaster } from 'react-hot-toast';
 
 const NotesCard = ({
   note,
@@ -64,7 +65,10 @@ const NotesCard = ({
 
       if (!response.ok) {
         const errorData = await response.json();
+        toast.error("Failed to upvote!");
         throw new Error(errorData.error || "Failed to update upvote");
+      } else {
+        toast.success(`Upvoted successfully!`);
       }
 
       // Optimistic UI update
@@ -74,7 +78,7 @@ const NotesCard = ({
       setNotes(updatedNotes);
     } catch (error) {
       console.error("Upvote error:", error);
-      alert(error.message || "Something went wrong.");
+      toast.error("Something went wrong!");
       // Revert optimistic update
       fetchNotes(page);
     }
@@ -82,6 +86,7 @@ const NotesCard = ({
   };
 
   return (
+    <>
     <div
       key={note._id}
       className="bg-white rounded-xl shadow-md hover:shadow-xl transition-all duration-300 transform hover:-translate-y-1 overflow-hidden"
@@ -143,6 +148,8 @@ const NotesCard = ({
         </div>
       </div>
     </div>
+    <Toaster/>
+    </>
   );
 };
 

--- a/client/src/pages/NotesPage.jsx
+++ b/client/src/pages/NotesPage.jsx
@@ -6,7 +6,6 @@ import {
   getSubjectsForYearAndBranch,
 } from "../services/subjects";
 import NotesCard from "../components/NotesCard";
-import { ToastContainer, toast } from 'react-toastify';
 
 
 const NotesPage = () => {

--- a/client/src/pages/NotesPage.jsx
+++ b/client/src/pages/NotesPage.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 import React, { useState, useEffect } from "react";
 import { useAuth } from "../context/AuthContext";
 import {
@@ -5,7 +6,7 @@ import {
   getSubjectsForYearAndBranch,
 } from "../services/subjects";
 import NotesCard from "../components/NotesCard";
-
+import { ToastContainer, toast } from 'react-toastify';
 
 
 const NotesPage = () => {

--- a/client/src/pages/PyqsPage.jsx
+++ b/client/src/pages/PyqsPage.jsx
@@ -1,8 +1,11 @@
+/* eslint-disable no-unused-vars */
 import { useState, useEffect } from 'react';
 import { useAuth } from '../context/AuthContext';
 import React from 'react';
 import { getBranchesForYear, getSubjectsForYearAndBranch } from '../services/subjects';
 import { Link } from 'react-router-dom';
+import { ToastContainer, toast } from 'react-toastify';
+
 
 const PyqsPage = () => {
   const [pyqs, setPyqs] = useState([]);
@@ -153,12 +156,48 @@ const PyqsPage = () => {
             pyq._id === id ? { ...pyq, upvotes: [...pyq.upvotes, currentUser.emailtoSend] } : pyq
           )
         );
+
+        toast.success('Upvoted!', {
+            position: "bottom-right",
+            autoClose: 5000,
+            hideProgressBar: true,
+            closeOnClick: true,
+            pauseOnHover: false,
+            draggable: false,
+            progress: undefined,
+            theme: "light",
+          });
+
       } else {
         alert(`Error: ${data.error}`);
+
+        toast.error('Upvote Failed!', {
+            position: "bottom-right",
+            autoClose: 5000,
+            hideProgressBar: true,
+            closeOnClick: true,
+            pauseOnHover: false,
+            draggable: false,
+            progress: undefined,
+            theme: "light",
+          });
+
       }
     } catch (error) {
       console.error('Error during upvote:', error);
       alert('Something went wrong while upvoting.');
+
+      toast.error('Upvote Failed!', {
+            position: "bottom-right",
+            autoClose: 5000,
+            hideProgressBar: true,
+            closeOnClick: true,
+            pauseOnHover: false,
+            draggable: false,
+            progress: undefined,
+            theme: "light",
+          });
+
     }
   };
 

--- a/client/src/pages/PyqsPage.jsx
+++ b/client/src/pages/PyqsPage.jsx
@@ -4,7 +4,7 @@ import { useAuth } from '../context/AuthContext';
 import React from 'react';
 import { getBranchesForYear, getSubjectsForYearAndBranch } from '../services/subjects';
 import { Link } from 'react-router-dom';
-import { ToastContainer, toast } from 'react-toastify';
+import toast, { Toaster } from 'react-hot-toast';
 
 
 const PyqsPage = () => {
@@ -156,48 +156,15 @@ const PyqsPage = () => {
             pyq._id === id ? { ...pyq, upvotes: [...pyq.upvotes, currentUser.emailtoSend] } : pyq
           )
         );
-
-        toast.success('Upvoted!', {
-            position: "bottom-right",
-            autoClose: 5000,
-            hideProgressBar: true,
-            closeOnClick: true,
-            pauseOnHover: false,
-            draggable: false,
-            progress: undefined,
-            theme: "light",
-          });
-
+        //toast notification
+        toast.success('Upvoted successfully!');
       } else {
         alert(`Error: ${data.error}`);
-
-        toast.error('Upvote Failed!', {
-            position: "bottom-right",
-            autoClose: 5000,
-            hideProgressBar: true,
-            closeOnClick: true,
-            pauseOnHover: false,
-            draggable: false,
-            progress: undefined,
-            theme: "light",
-          });
-
+        toast.error(`Upvote failed!`);
       }
     } catch (error) {
       console.error('Error during upvote:', error);
-      alert('Something went wrong while upvoting.');
-
-      toast.error('Upvote Failed!', {
-            position: "bottom-right",
-            autoClose: 5000,
-            hideProgressBar: true,
-            closeOnClick: true,
-            pauseOnHover: false,
-            draggable: false,
-            progress: undefined,
-            theme: "light",
-          });
-
+      toast.error(`Something went wrong while upvoting.`);
     }
   };
 
@@ -439,6 +406,7 @@ const PyqsPage = () => {
           </div>
         </div>
       )}
+      <Toaster />
     </>
   );
 };

--- a/server/Routes/index.js
+++ b/server/Routes/index.js
@@ -194,7 +194,7 @@ Router.post('/upload-notes', mainmiddleware, upload.single('file'), async (req, 
       year,
       branch,
       subject,
-      user: UUser._id,
+      uploader: UUser._id,
       fileurl: url,
     });
     console.log("the uploader id is as follows",note.user, url)
@@ -306,9 +306,8 @@ Router.use((err, req, res, next) => {
           year: sanitizedYear,
           branch,
           subject: sanitizedSubject,
-          user: UUser._id,
+          uploader: UUser._id,
           fileurl: url,
-          // Remove this line: upvotes: 0,
           createdAt: new Date()
         });
         console.log("the user uploader is",pyq, url);
@@ -409,9 +408,11 @@ Router.post('/notes/:id/upvote', mainmiddleware, async (req, res) => {
 
     note.upvotes.push(user._id);
    
-    if (!note.uploader) {
-      note.uploader = user._id; // or some default ID
-    }
+    // This is wrong, setting the current users id as the uploader isnt supposed to happen.
+    // it should set uploader id only when creating the note & it should be the uploader id.
+    // This is the reason why notes upvote worked, because you are uploading the user id when creating the post but not uploader
+    // so it is empty but when u do this the db will not return a error when saving because if was set to user._id before saving
+
     await note.save(); // 🔥 Save point
     console.log("Note saved successfully");
 

--- a/server/models/notes/model.js
+++ b/server/models/notes/model.js
@@ -11,12 +11,8 @@ const notesSchema = mongoose.Schema({
     },
     uploader: {
     type: mongoose.Schema.Types.ObjectId,
-    ref: 'User', // reference to the User model
+    ref: 'user', // reference to the User model
     required: true,
-  },
-  branch: {
-    type: mongoose.Schema.Types.ObjectId,
-    ref: 'Branch', // optional, only if you use branches
   },
     branch:{
         type:"string",

--- a/server/models/pyq/model.js
+++ b/server/models/pyq/model.js
@@ -20,12 +20,8 @@ const pyqSchema = new mongoose.Schema({
   },
   uploader: {
     type: mongoose.Schema.Types.ObjectId,
-    ref: 'User',
+    ref: 'user',
     required: true,
-  },
-  branch: {
-    type: mongoose.Schema.Types.ObjectId,
-    ref: 'Branch',
   },
   fileurl: {
     type: String,


### PR DESCRIPTION
The issue that caused the PYQs upvote button to not work as expected was because the uploader attribute returned from the database was empty, the upvote button for the notes worked because before saving the upvoted user's id was being set to uploaders id.

This wasn't done in PYQs so it failed to work. However setting the upvoting user's id as the uploader id of the post is something that shouldn't happen.

The following error was returned from the server when the upvote button in PYQs was clicked:

`"pyqs validation failed: branch: Cast to ObjectId failed for value \"CSE\" (type string) at path \"branch\" because of \"BSONError\", uploader: Path 'uploader' is required."`

The branch attribute in both Notes & PYQs DB model was set to a **Object** instead of a **String**, so the `Cast to ObjectId failed` error was returned.

The upvote button in Notes worked because in both DB models there was 2 **branch** schema paths, in the notes model one branch schema path was created with the data type **Object** and another one with the data type **String**, so the DB discarded the first one with the **Object** data type. So there wasn't any error.

In the PYQs model though it was the opposite, the schema path with the **String** data type was added before the second schema path with the **Object** data type, so the DB discarded the schema path with **String** data type which resulted in the `uploader: Path 'uploader' is required.` error.

Also in Notes & PYQs upload API the uploader id wasn't given, instead the user id was set to the user attribute in DB, that's why the uploader attribute was empty so i changed it to uploader

This was the extra `branch ` schema path
  ```
branch: {
    type: mongoose.Schema.Types.ObjectId,
    ref: 'Branch',
  },
```
This was the block of code that was setting the upvoting user's id as the uploader's id if it was empty.
```
if (!note.uploader) {
      note.uploader = user._id; // or some default ID
    }

```